### PR TITLE
feat(DataModel): deprecate map comments' methods

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9922,9 +9922,9 @@
       }
     },
     "node_modules/wme-sdk-typings": {
-      "version": "v2.278-3-ga6f1d33d1",
+      "version": "v2.340-9-gb80fecfb7a",
       "resolved": "https://web-assets.waze.com/wme_sdk_docs/production/latest/wme-sdk-typings.tgz",
-      "integrity": "sha512-B8nzVCrkyOJU6Q21LHJRXSYLlyNCToxaO7EHGdJWZUbhyqfDYftQwzAxb+9wmnVhMmG4ZzExhLuqbbo+ysBx1w==",
+      "integrity": "sha512-NFLwMFGg1pXnGqAINy9m9fz4utQTfzbP5/rr7Hm4DXImNVX17NhOPjdJiILVomV9YY5OWpspLXfXn/qQUbAPgA==",
       "dev": true,
       "license": "UNLICENSED",
       "peerDependencies": {
@@ -10129,6 +10129,7 @@
       "version": "0.0.1",
       "dependencies": {
         "@turf/helpers": "^7.2.0",
+        "@wme-enhanced-sdk/patch-editing--transactions": "^0.0.1",
         "geojson": "^0.5.0"
       }
     },

--- a/packages/patch-datamodel--mapcomments/package.json
+++ b/packages/patch-datamodel--mapcomments/package.json
@@ -16,6 +16,7 @@
   },
   "dependencies": {
     "@turf/helpers": "^7.2.0",
+    "@wme-enhanced-sdk/patch-editing--transactions": "^0.0.1",
     "geojson": "^0.5.0"
   }
 }

--- a/packages/patch-datamodel--mapcomments/src/index.ts
+++ b/packages/patch-datamodel--mapcomments/src/index.ts
@@ -95,9 +95,9 @@ export default [
 
   new DefinePropertyRule('DataModel.MapComments.updateMapComment', ({ sdk }: { sdk: WmeSDK }) => {
     if (typeof sdk.DataModel.MapComments.updateComment === 'function') {
-      console.warn('[WME SDK+]: "MapComments.updateMapComment" method from SDK+ is deprecated. Please use "MapComments.addComment" from the official SDK instead. This method will cease to exist in future SDK+ versions');
-
       return (args: UpdateMapCommentsArgs) => {
+        console.warn('[WME SDK+]: "MapComments.updateMapComment" method from SDK+ is deprecated. Please use "MapComments.updateComment" from the official SDK instead. This method will cease to exist in future SDK+ versions');
+
         doActions(() => {
           const mapComment = sdk.DataModel.MapComments.updateComment({
             mapCommentId: args.mapCommentId,

--- a/packages/patch-datamodel--mapcomments/src/index.ts
+++ b/packages/patch-datamodel--mapcomments/src/index.ts
@@ -101,8 +101,8 @@ export default [
         doActions(() => {
           const mapComment = sdk.DataModel.MapComments.updateComment({
             mapCommentId: args.mapCommentId,
-            subject: args.subject ?? "",
-            body: args.body ?? "",
+            subject: args.subject,
+            body: args.body,
             geometry: args.geometry,
           });
 

--- a/packages/patch-datamodel--mapcomments/src/index.ts
+++ b/packages/patch-datamodel--mapcomments/src/index.ts
@@ -8,6 +8,7 @@ import { UpdateMapCommentsArgs } from './lib/update-map-comments-args.js';
 import { getMapComment } from './lib/get-map-comment.js';
 import { pushUpdateObjectAction } from './lib/update-object-action.js';
 import { WmeSDK } from 'wme-sdk-typings';
+import { doActions } from '@wme-enhanced-sdk/patch-editing--transactions';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 let MapComment: any;
@@ -26,21 +27,106 @@ export default [
     },
   } as SdkPatcherRule,
 
-  new DefinePropertyRule('DataModel.MapComments.addMapComment', (args: AddMapCommentArgs) => {
-    assertMapCommentResolved();
+  new DefinePropertyRule('DataModel.MapComments.addMapComment', ({ sdk }: { sdk: WmeSDK }) => {
+    if (typeof sdk.DataModel.MapComments.addComment === 'function') {
+      return (args: AddMapCommentArgs) => {
+        console.warn('[WME SDK+]: "MapComments.addMapComment" method from SDK+ is deprecated. Please use "MapComments.addComment" from the official SDK instead. This method will cease to exist in future SDK+ versions');
 
-    const mapComment = new MapComment({
-      geoJSONGeometry: args.geometry,
-      subject: args.subject,
-      body: args.body,
-      lockRank: args.lockRank,
-      endDate: args.endDate ? formatEndDate(args.endDate) : null,
-    });
-    pushCreateObjectAction(mapComment);
-    return mapComment.getID();
-  }),
+        const mapComment = doActions(() => {
+          const mapComment = sdk.DataModel.MapComments.addComment({
+            subject: args.subject ?? "",
+            body: args.body ?? "",
+            endDate: args.endDate ? args.endDate.getTime() / 1000 : 0,
+            geometry: args.geometry,
+          });
+
+          // Waze requires all attributes in their interface to be provided, yet they..
+          // ..miss some of the other attributes we could set.
+          // After we have added the map comment using the native SDK implementation,..
+          // ..we will collect a list of other attribtues to set/modify, to match the expected..
+          // ..behavior of our function.
+          //
+          // For example, Waze requires an expiration date (endDate) to be provided.
+          // This is counter intuitive and unnecessary, and sometimes illogical..
+          // ..yet, they require it. When adding the map comment using the SDK,..
+          // ..we will provide a default value (of 0) so their implementation won't fail,..
+          // ..and afterwards, as we manage the data, we'll clear the expiration date using the legacy "UpdateObject" action.
+          // The same will be true for setting attributes that are otherwise aren't supported by the SDK implementation.
+          const attributesToSet: Record<string, unknown> = {};
+          if (args.lockRank !== undefined) {
+            attributesToSet.lockRank = args.lockRank;
+          }
+          if (!args.endDate) {
+            // Waze forces us (in SDK v2.340-9) into setting an expiration date..
+            // ..but our implementation does not require it, so when we receive no expiration date..
+            // ..we will use a default value on the addComment implementation, and here we'll clear it.
+            attributesToSet.endDate = null;
+          }
+
+          if (Object.keys(attributesToSet).length > 0) {
+            const wmeMapComment = getMapComment(mapComment.id);
+            if (!wmeMapComment)
+              throw new sdk.Errors.WMEError("Unable to retrieve a reference to the WME MapComment object to update it's attributes.");
+
+            pushUpdateObjectAction(wmeMapComment, attributesToSet);
+          }
+
+          return mapComment;
+        });
+        
+        return mapComment.id;
+      };
+    }
+
+    return (args: AddMapCommentArgs) => {
+      assertMapCommentResolved();
+
+      const mapComment = new MapComment({
+        geoJSONGeometry: args.geometry,
+        subject: args.subject,
+        body: args.body,
+        lockRank: args.lockRank,
+        endDate: args.endDate ? formatEndDate(args.endDate) : null,
+      });
+      pushCreateObjectAction(mapComment);
+      return mapComment.getID();
+    }
+  }, { isFactory: true }),
 
   new DefinePropertyRule('DataModel.MapComments.updateMapComment', ({ sdk }: { sdk: WmeSDK }) => {
+    if (typeof sdk.DataModel.MapComments.updateComment === 'function') {
+      console.warn('[WME SDK+]: "MapComments.updateMapComment" method from SDK+ is deprecated. Please use "MapComments.addComment" from the official SDK instead. This method will cease to exist in future SDK+ versions');
+
+      return (args: UpdateMapCommentsArgs) => {
+        doActions(() => {
+          const mapComment = sdk.DataModel.MapComments.updateComment({
+            mapCommentId: args.mapCommentId,
+            subject: args.subject ?? "",
+            body: args.body ?? "",
+            geometry: args.geometry,
+          });
+
+          // Waze requires all attributes in their interface to be provided, yet they..
+          // ..miss some of the other attributes we could set.
+          // After we have added the map comment using the native SDK implementation,..
+          // ..we will collect a list of other attribtues to set/modify, to match the expected..
+          // ..behavior of our function.
+          const attributesToSet: Record<string, unknown> = {};
+          if (args.lockRank !== undefined) {
+            attributesToSet.lockRank = args.lockRank;
+          }
+
+          if (Object.keys(attributesToSet).length > 0) {
+            const wmeMapComment = getMapComment(mapComment.id);
+            if (!wmeMapComment)
+              throw new sdk.Errors.WMEError("Unable to retrieve a reference to the WME MapComment object to update it's attributes.");
+
+            pushUpdateObjectAction(wmeMapComment, attributesToSet);
+          }
+        });
+      }
+    };
+
     return (args: UpdateMapCommentsArgs) => {
       const mapComment = getMapComment(args.mapCommentId);
       if (!mapComment) {

--- a/packages/patch-datamodel--mapcomments/src/index.ts
+++ b/packages/patch-datamodel--mapcomments/src/index.ts
@@ -40,11 +40,11 @@ export default [
     return mapComment.getID();
   }),
 
-  new DefinePropertyRule('DataModel.MapComments.updateMapComment', ({ sdkInstance }: { sdkInstance: WmeSDK }) => {
+  new DefinePropertyRule('DataModel.MapComments.updateMapComment', ({ sdk }: { sdk: WmeSDK }) => {
     return (args: UpdateMapCommentsArgs) => {
       const mapComment = getMapComment(args.mapCommentId);
       if (!mapComment) {
-        throw new sdkInstance.Errors.DataModelNotFoundError('mapComment', args.mapCommentId);
+        throw new sdk.Errors.DataModelNotFoundError('mapComment', args.mapCommentId);
       }
 
       // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/patch-datamodel--mapcomments/src/index.ts
+++ b/packages/patch-datamodel--mapcomments/src/index.ts
@@ -138,7 +138,7 @@ export default [
       if (args.geometry) newAttributes.geoJSONGeometry = args.geometry;
       if (args.subject) newAttributes.subject = args.subject;
       if (args.body) newAttributes.body = args.body;
-      if (args.lockRank) newAttributes.lockRank = args.lockRank;
+      if (args.lockRank !== undefined) newAttributes.lockRank = args.lockRank;
   
       pushUpdateObjectAction(mapComment, newAttributes);
     }

--- a/packages/patch-datamodel--mapcomments/tsconfig.json
+++ b/packages/patch-datamodel--mapcomments/tsconfig.json
@@ -13,6 +13,9 @@
       "path": "../sdk-patcher"
     },
     {
+      "path": "../patch-editing--transactions"
+    },
+    {
       "path": "./tsconfig.lib.json"
     },
     {

--- a/packages/patch-datamodel--mapcomments/tsconfig.lib.json
+++ b/packages/patch-datamodel--mapcomments/tsconfig.lib.json
@@ -19,6 +19,9 @@
     },
     {
       "path": "../sdk-patcher/tsconfig.lib.json"
+    },
+    {
+      "path": "../patch-editing--transactions/tsconfig.lib.json"
     }
   ],
   "exclude": [

--- a/packages/patch-editing--transactions/src/index.ts
+++ b/packages/patch-editing--transactions/src/index.ts
@@ -23,10 +23,26 @@ export function commitTransaction(description?: string, manager: TransactionMana
 export function cancelTransaction(manager: TransactionManager = getTransactionManager()): void {
   manager.cancelTransaction();
 }
-export function doActions<T>(cb: () => T, description?: string, manager?: TransactionManager): T {
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function doActions<T>(cb: () => T extends Promise<any> ? never : T, description?: string, manager?: TransactionManager): T {
   beginTransaction(manager);
   try {
     const result = cb();
+    if (result instanceof Promise) {
+      console.error(
+        'doActions detected an async callback. Async operations are not supported because ' +
+        'actions added after the transaction closes cannot be captured. Complete async work ' +
+        'before calling doActions, or use synchronous callbacks only.\n\n' +
+
+        'The provided callback will continue to execute in this session and may have side-effects ' +
+        'on the WME session, and may have the actions generated within that callback to leak outside ' +
+        'the boundaries of the transaction into the change log.'
+      );
+      cancelTransaction(manager);
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      return undefined!;
+    }
+
     commitTransaction(description, manager);
     return result;
   } catch (e) {
@@ -34,6 +50,7 @@ export function doActions<T>(cb: () => T, description?: string, manager?: Transa
     throw e;
   }
 }
+
 export default [
   new DefinePropertyRule(
     'Editing.beginTransaction',
@@ -49,6 +66,7 @@ export default [
   ),
   new DefinePropertyRule(
     'Editing.doActions',
-    <T>(cb: () => T, description?: string) => doActions(cb, description)
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    <T>(cb: () => T extends Promise<any> ? never : T, description?: string) => doActions(cb, description)
   ),
 ];

--- a/packages/patch-editing--transactions/src/index.ts
+++ b/packages/patch-editing--transactions/src/index.ts
@@ -23,11 +23,12 @@ export function commitTransaction(description?: string, manager: TransactionMana
 export function cancelTransaction(manager: TransactionManager = getTransactionManager()): void {
   manager.cancelTransaction();
 }
-export function doActions(cb: () => void, description?: string, manager?: TransactionManager): void {
+export function doActions<T>(cb: () => T, description?: string, manager?: TransactionManager): T {
   beginTransaction(manager);
   try {
-    cb();
+    const result = cb();
     commitTransaction(description, manager);
+    return result;
   } catch (e) {
     cancelTransaction(manager);
     throw e;
@@ -48,6 +49,6 @@ export default [
   ),
   new DefinePropertyRule(
     'Editing.doActions',
-    (cb: () => void, description?: string) => doActions(cb, description)
+    <T>(cb: () => T, description?: string) => doActions(cb, description)
   ),
 ];

--- a/packages/patch-editing--transactions/src/index.ts
+++ b/packages/patch-editing--transactions/src/index.ts
@@ -14,31 +14,40 @@ function getTransactionManager() {
   return transactionManager;
 }
 
+export function beginTransaction(manager: TransactionManager = getTransactionManager()): void {
+  manager.beginTransaction();
+}
+export function commitTransaction(description?: string, manager: TransactionManager = getTransactionManager()): void {
+  manager.commitTransaction(description);
+}
+export function cancelTransaction(manager: TransactionManager = getTransactionManager()): void {
+  manager.cancelTransaction();
+}
+export function doActions(cb: () => void, description?: string, manager?: TransactionManager): void {
+  beginTransaction(manager);
+  try {
+    cb();
+    commitTransaction(description, manager);
+  } catch (e) {
+    cancelTransaction(manager);
+    throw e;
+  }
+}
 export default [
   new DefinePropertyRule(
     'Editing.beginTransaction',
-    () => getTransactionManager().beginTransaction(),
+    () => beginTransaction(),
   ),
   new DefinePropertyRule(
     'Editing.commitTransaction',
-    (description?: string) => getTransactionManager().commitTransaction(description),
+    (description?: string) => commitTransaction(description),
   ),
   new DefinePropertyRule(
     'Editing.cancelTransaction',
-    () => getTransactionManager().cancelTransaction(),
+    () => cancelTransaction(),
   ),
   new DefinePropertyRule(
     'Editing.doActions',
-    (cb: () => void, description?: string) => {
-      const transactionManager = getTransactionManager();
-      transactionManager.beginTransaction();
-      try {
-        cb();
-        transactionManager.commitTransaction(description);
-      } catch (e) {
-        transactionManager.cancelTransaction();
-        throw e;
-      }
-    }
+    (cb: () => void, description?: string) => doActions(cb, description)
   ),
 ];


### PR DESCRIPTION
This pull request introduces significant enhancements to the `patch-datamodel--mapcomments` package, focusing on improved integration with the official SDK for map comment management and robust transaction handling. The changes modernize the way map comments are added and updated, ensuring compatibility with the official SDK and providing better error messaging and attribute management. Additionally, transaction management utilities are refactored and exported for broader use.

**Integration with official SDK and transaction management:**

* Refactored `addMapComment` and `updateMapComment` methods to use the official SDK's `addComment` and `updateComment` when available, with fallback to legacy implementations. Added warnings about deprecation and improved attribute handling for unsupported attributes like `lockRank`, which will be fulfilled if possible, and will reject the request otherwise, with proper error messaging.
* Transaction handling for these unsupported attributes is wrapped with the new `doActions` utility for atomic operations.

**Transaction utilities refactoring:**

* Exported new transaction management functions (`beginTransaction`, `commitTransaction`, `cancelTransaction`, `doActions`), and refactored the default export rules to use these utilities, making transaction handling reusable and more robust across packages.

**SDK+ deprecation and attribute handling:**

* Added console warnings in `addMapComment` and `updateMapComment` to inform users of deprecation, improving developer experience and guiding migration to the official SDK.

These changes collectively improve reliability, maintainability, and developer guidance for map comment editing and transaction management in the enhanced SDK ecosystem.