### PR TITLE
feat: implement DataModel.BigJunctions.deleteBigJunction method

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10224,6 +10224,9 @@
     "packages/wme-utils": {
       "name": "@wme-enhanced-sdk/wme-utils",
       "version": "0.0.1",
+      "dependencies": {
+        "@wme-enhanced-sdk/method-interceptor": "^0.0.1"
+      },
       "devDependencies": {
         "@types/backbone": "^1.4.23"
       }

--- a/packages/method-interceptor/src/lib/method-interceptor.ts
+++ b/packages/method-interceptor/src/lib/method-interceptor.ts
@@ -34,6 +34,23 @@ export class MethodInterceptor<
     this._interceptionFunction = interceptionFunction;
   }
 
+  static mockReturnValueOnce<Target extends object, FnKey extends KeysOfFunctions<Target>>(
+    targetObject: Target,
+    functionName: FnKey,
+    returnValue: ReturnType<FunctionOfTarget<Target, FnKey>>,
+  ) {
+    const interceptor = new MethodInterceptor(
+      targetObject,
+      functionName,
+      () => {
+        interceptor.restore();
+        return returnValue;
+      }
+    );
+    interceptor.enable();
+    return interceptor;
+  }
+
   get enabled() {
     return this._fnSwapper.isSwapped && this._enabled;
   }

--- a/packages/patch-datamodel--bigjunctions/src/artifact-symbols.ts
+++ b/packages/patch-datamodel--bigjunctions/src/artifact-symbols.ts
@@ -1,2 +1,3 @@
 export const BIG_JUNCTION_DM = Symbol('BigJunction');
 export const ADD_BIG_JUNCTION_ACTION = Symbol('AddBigJunction');
+export const DELETE_BIG_JUNCTION_ACTION = Symbol('DeleteBigJunction');

--- a/packages/patch-datamodel--bigjunctions/src/index.ts
+++ b/packages/patch-datamodel--bigjunctions/src/index.ts
@@ -3,10 +3,12 @@ import addBigJunctionRules from './rules/add-big-junction.rules.js';
 import configureArtifactsRules from './rules/configure-artifacts.rules.js';
 import updateBigJunctionRules from './rules/update-big-junction.rules.js';
 import updateBigJunctionAddressRules from './rules/update-big-junction-address.rules.js';
+import deleteBigJunctionRules from './rules/delete-big-junction.rules.js';
 
 export default [
   ...configureArtifactsRules,
   ...addBigJunctionRules,
+  ...deleteBigJunctionRules,
   ...updateBigJunctionRules,
   ...updateBigJunctionAddressRules,
 ] as SdkPatcherRule[];

--- a/packages/patch-datamodel--bigjunctions/src/rules/configure-artifacts.rules.ts
+++ b/packages/patch-datamodel--bigjunctions/src/rules/configure-artifacts.rules.ts
@@ -24,7 +24,7 @@ export default [
         throw new Error('Unexpected state: Added object does not exist');
 
       if (addedObject.type !== 'bigJunction')
-        throw new Error('Unexpected state: Expected the added object to be a BigJunction instead of ' + addedAction.type);
+        throw new Error('Unexpected state: Expected the added object to be a BigJunction instead of ' + addedObject.type);
 
       return {
         [BIG_JUNCTION_DM]: addedObject.constructor,

--- a/packages/patch-datamodel--bigjunctions/src/rules/configure-artifacts.rules.ts
+++ b/packages/patch-datamodel--bigjunctions/src/rules/configure-artifacts.rules.ts
@@ -1,11 +1,11 @@
 import { polygon } from '@turf/helpers';
-import { SdkPatcherRule } from '@wme-enhanced-sdk/sdk-patcher';
-import { captureAsyncActions, drawFeature } from '@wme-enhanced-sdk/wme-utils';
-import { ADD_BIG_JUNCTION_ACTION, BIG_JUNCTION_DM } from '../artifact-symbols.js';
+import { SdkPatcherRule, SdkPatcherRuleOperationArgs } from '@wme-enhanced-sdk/sdk-patcher';
+import { captureAsyncActions, drawFeature, scrapeDeleteObjectAction } from '@wme-enhanced-sdk/wme-utils';
+import { ADD_BIG_JUNCTION_ACTION, BIG_JUNCTION_DM, DELETE_BIG_JUNCTION_ACTION } from '../artifact-symbols.js';
 
 export default [
   {
-    async install() {
+    async install(args: SdkPatcherRuleOperationArgs) {
       const drawBigJunctionMenuItem = document.querySelector('#drawer wz-menu > wz-menu-sub-menu:nth-child(1) > wz-menu-item:nth-of-type(4)');
       if (!drawBigJunctionMenuItem || !(drawBigJunctionMenuItem instanceof HTMLElement))
         throw new Error('Unable to find school zone drawing menu item');
@@ -26,9 +26,12 @@ export default [
       if (addedObject.type !== 'bigJunction')
         throw new Error('Unexpected state: Expected the added object to be a BigJunction instead of ' + addedObject.type);
 
+      const deletedActionConstructor = scrapeDeleteObjectAction(args.sdk, addedObject, 'DELETE_BIG_JUNCTION');
+
       return {
         [BIG_JUNCTION_DM]: addedObject.constructor,
         [ADD_BIG_JUNCTION_ACTION]: addedAction.constructor,
+        [DELETE_BIG_JUNCTION_ACTION]: deletedActionConstructor,
       };
     },
   }

--- a/packages/patch-datamodel--bigjunctions/src/rules/delete-big-junction.rules.ts
+++ b/packages/patch-datamodel--bigjunctions/src/rules/delete-big-junction.rules.ts
@@ -1,0 +1,25 @@
+import { DefinePropertyRule, SdkPatcherRule, SdkPatcherRuleOperationArgs } from '@wme-enhanced-sdk/sdk-patcher';
+import { getBigJunction } from '../utils/get-big-junction.js';
+import { DELETE_BIG_JUNCTION_ACTION } from '../artifact-symbols.js';
+import { getWindow } from '@wme-enhanced-sdk/utils';
+
+interface DeleteBigJunctionArgs {
+  bigJunctionId: number;
+}
+
+export default [
+  new DefinePropertyRule('DataModel.BigJunctions.deleteBigJunction', ({ sdk, artifacts }: SdkPatcherRuleOperationArgs) => {
+    return (args: DeleteBigJunctionArgs) => {
+      const bigJunction = getBigJunction(args.bigJunctionId);
+      if (!bigJunction) {
+        throw new sdk.Errors.DataModelNotFoundError('bigJunction', args.bigJunctionId);
+      }
+
+      const DeleteBigJunction = artifacts[DELETE_BIG_JUNCTION_ACTION];
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const model = getWindow<{ W: any }>().W.model;
+      const action = new DeleteBigJunction(bigJunction);
+      model.actionManager.add(action);
+    };
+  }, { isFactory: true }),
+] as SdkPatcherRule[];

--- a/packages/wme-utils/package.json
+++ b/packages/wme-utils/package.json
@@ -16,5 +16,8 @@
   },
   "devDependencies": {
     "@types/backbone": "^1.4.23"
+  },
+  "dependencies": {
+    "@wme-enhanced-sdk/method-interceptor": "^0.0.1"
   }
 }

--- a/packages/wme-utils/src/index.ts
+++ b/packages/wme-utils/src/index.ts
@@ -1,6 +1,7 @@
 export * from './lib/capture-actions.js';
 export * from './lib/create-empty-data-model.js';
 export * from './lib/draw-feature.js';
+export * from './lib/scrape-delete-object-action.js';
 export * from './lib/resolve-entity-prototype.js';
 export * from './lib/run-with-model.js';
 export * from './lib/scrape-update-feature-address-action.js';

--- a/packages/wme-utils/src/lib/data-model.d.ts
+++ b/packages/wme-utils/src/lib/data-model.d.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-import type { Collection, Model } from 'backbone';
+import type { Model } from 'backbone';
 
 type EntitiesType =
   | 'bigJunctions'
@@ -44,10 +44,10 @@ type EntitiesType =
 export type DataModel = {
   actionManager: ActionManager;
 
-  repos: Record<EntitiesType, Collection>;
-  [repoName in EntitiesType]: Collection;
+  repos: Record<EntitiesType, any>;
+  [repoName in EntitiesType]: any;
   isRepository(name: string): name is EntitiesType;
-  getRepositories(): Record<EntitiesType, Collection>;
+  getRepositories(): Record<EntitiesType, any>;
 
   clone(): DataModel;
   mergeObjects(

--- a/packages/wme-utils/src/lib/scrape-delete-object-action.ts
+++ b/packages/wme-utils/src/lib/scrape-delete-object-action.ts
@@ -21,12 +21,17 @@ export function scrapeDeleteObjectAction(sdk: WmeSDK, object: Model, actionName:
 
   dataModel.repos['venues'].objects['__object'] = object;
   const [action] = runWithModel(dataModel, () => {
-    MethodInterceptor.mockReturnValueOnce(object, 'isNew', true);
-    MethodInterceptor.mockReturnValueOnce(getEditingMediator(), 'isEditingAllowed', true);
+    const isNewInterceptor = MethodInterceptor.mockReturnValueOnce(object, 'isNew', true);
+    const isEditingAllowedInterceptor = MethodInterceptor.mockReturnValueOnce(getEditingMediator(), 'isEditingAllowed', true);
 
-    return captureActions(() => {
-      sdk.DataModel.Venues.deleteVenue({ venueId: '__object' });
-    }, { model: dataModel });
+    try {
+      return captureActions(() => {
+        sdk.DataModel.Venues.deleteVenue({ venueId: '__object' });
+      }, { model: dataModel });
+    } finally {
+      isNewInterceptor.restore();
+      isEditingAllowedInterceptor.restore();
+    }
   });
   delete dataModel.repos['venues'].objects['__object'];
   if (action.actionName !== actionName) {

--- a/packages/wme-utils/src/lib/scrape-delete-object-action.ts
+++ b/packages/wme-utils/src/lib/scrape-delete-object-action.ts
@@ -1,0 +1,37 @@
+import type { Model } from 'backbone';
+import { createEmptyDataModel } from './create-empty-data-model.js';
+import type { DataModel } from './data-model.js';
+import { runWithModel } from './run-with-model.js';
+import { WmeSDK } from 'wme-sdk-typings';
+import { MethodInterceptor } from '@wme-enhanced-sdk/method-interceptor';
+import { getWindow } from '@wme-enhanced-sdk/utils';
+import { captureActions } from './capture-actions.js';
+
+let cachedDataModel: DataModel | null = null;
+
+function getEditingMediator() {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const window = getWindow<{ W: any }>();
+  return window.W.editingMediator;
+}
+
+export function scrapeDeleteObjectAction(sdk: WmeSDK, object: Model, actionName: string) {
+  const dataModel = cachedDataModel ??= createEmptyDataModel();
+  if (!dataModel) throw new Error('Failed to create empty data model');
+
+  dataModel.repos['venues'].objects['__object'] = object;
+  const [action] = runWithModel(dataModel, () => {
+    MethodInterceptor.mockReturnValueOnce(object, 'isNew', true);
+    MethodInterceptor.mockReturnValueOnce(getEditingMediator(), 'isEditingAllowed', true);
+
+    return captureActions(() => {
+      sdk.DataModel.Venues.deleteVenue({ venueId: '__object' });
+    }, { model: dataModel });
+  });
+  delete dataModel.repos['venues'].objects['__object'];
+  if (action.actionName !== actionName) {
+    throw new Error(`Unexpected action discovered when tried to resolve ${actionName} action: ${action.actionName}`);
+  }
+
+  return action.constructor;
+}


### PR DESCRIPTION
This pull request adds a long-awaited feature to programmatically delete an existing big junction from the map.

# Implementation Details

The implementation relies on the `DataModel.Venues.deleteVenue` method, which triggers the comprehensive flow of the WME to delete any object. The `deleteVenue` method works by retrieving the venue entity from the data model and passing it to the comprehensive handler.

To implement the big junction deletion method, it temporarily patches and inserts in an empty data model, into the venues repository, a big junction entity, then proceeds to call the `Venues.deleteVenue` method. Since it does not validate the actual entity type from the repository, it proceeds with the original flow, which actually checks for the type of entity to delete, and instantiates the dedicated action for deleting a big junction.

It then caches it and reuses the prepopulated action constructor to delete big junctions on demand.