### PR TITLE
fix(patch-events): prevent stack overflow in sidebar tab opened event

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10185,7 +10185,8 @@
       "dependencies": {
         "@wme-enhanced-sdk/method-interceptor": "^0.0.1",
         "@wme-enhanced-sdk/sdk-patcher": "^0.0.1",
-        "@wme-enhanced-sdk/utils": "^0.0.1"
+        "@wme-enhanced-sdk/utils": "^0.0.1",
+        "reflect-metadata": "^0.2.2"
       }
     },
     "packages/patch-middleware": {
@@ -10226,6 +10227,7 @@
       "version": "0.0.1",
       "dependencies": {
         "@wme-enhanced-sdk/patch-datamodel--bigjunctions": "^0.0.1",
+        "@wme-enhanced-sdk/patch-editing--custom-actions": "^0.0.1",
         "@wme-enhanced-sdk/patch-events": "^0.0.1",
         "@wme-enhanced-sdk/patch-middleware": "^0.0.1"
       }

--- a/packages/patch-events/package.json
+++ b/packages/patch-events/package.json
@@ -17,6 +17,7 @@
   "dependencies": {
     "@wme-enhanced-sdk/method-interceptor": "^0.0.1",
     "@wme-enhanced-sdk/sdk-patcher": "^0.0.1",
-    "@wme-enhanced-sdk/utils": "^0.0.1"
+    "@wme-enhanced-sdk/utils": "^0.0.1",
+    "reflect-metadata": "^0.2.2"
   }
 }

--- a/packages/patch-events/src/events/sidebar-tabs/sidebar-tab-rendered.ts
+++ b/packages/patch-events/src/events/sidebar-tabs/sidebar-tab-rendered.ts
@@ -1,3 +1,4 @@
+import 'reflect-metadata';
 import type { WmeSDK } from 'wme-sdk-typings';
 import { getWindow } from '@wme-enhanced-sdk/utils';
 import { createEventDefinition } from '../../lib/index.js';
@@ -52,17 +53,24 @@ type SidebarTabOpenedPayload = Extract<AllEventPayloads, { domId: unknown, tabNa
 export const sidebarTabRenderedEvent = createEventDefinition(
   'wme-sidebar-tab-opened',
   ({ trigger, eventBus }) => {
-    const eventHandler = ({ domId, tabName }: SidebarTabOpenedPayload) => {
+    const eventHandler = (payload: SidebarTabOpenedPayload) => {
+      if (Reflect.getMetadata('wme-sdk:enriched', payload)) return;
+
       const window = getWindow();
-      const tabElement = window.document.getElementById(domId);
-      trigger({
-        tabName,
-        domId,
+      const tabElement = window.document.getElementById(payload.domId as string);
+
+      const enrichedPayload = {
+        tabName: payload.tabName,
+        domId: payload.domId,
         tabType: tabElement && isSidebarTabPane(tabElement)
                     ? SIDEBAR_TAB_PANES_TO_SCRIPT_TYPES[SIDEBAR_TAB_PANES_TO_TYPES[tabElement.id]]
                     : undefined,
         tabElement: tabElement && isSidebarTabPane(tabElement) ? tabElement : undefined,
-      });
+      };
+
+      Reflect.defineMetadata('wme-sdk:enriched', true, enrichedPayload);
+
+      trigger(enrichedPayload);
     };
 
     // this is essential to subscribe on the event bus directly instead of via SDK.Events.on,


### PR DESCRIPTION
The sidebar tab opened event native subscription was causing infinite recursion because the enriched event triggered on the event bus was matching the original native event subscription handler again.

This patch adds `reflect-metadata` to set an enrichment marker ('wme-sdk:enriched') on the payload, allowing the native event handler to immediately return if the payload has already been enriched.

---
*PR created automatically by Jules for task [14845320566068370268](https://jules.google.com/task/14845320566068370268) started by @davidsl4*