### PR TITLE
feat: support nested transactions in Editing.Transactions module

### DIFF
--- a/packages/patch-editing--transactions/src/transaction-manager.spec.ts
+++ b/packages/patch-editing--transactions/src/transaction-manager.spec.ts
@@ -43,11 +43,8 @@ describe('TransactionManager', () => {
     // which is the mock we provided.
     manager['_actionManagerAddInterceptor'].callOriginalInvocator = vi.fn();
 
-    // Since we mock it manually, let's call the interceptor manually for test ease
-    manager['activeTransaction']?.acceptAction(
-      action1,
-      actionManager.dataModel
-    );
+    // add an action using actionManager.add (this should trigger interceptor)
+    actionManager.add(action1);
 
     manager.commitTransaction('My Description');
 
@@ -64,10 +61,7 @@ describe('TransactionManager', () => {
       undoAction: vi.fn(),
       undoSupported: () => true,
     } as unknown as Action;
-    manager['activeTransaction']?.acceptAction(
-      action1,
-      actionManager.dataModel
-    );
+    actionManager.add(action1);
 
     manager.beginTransaction(); // inner
     const action2 = {
@@ -75,10 +69,7 @@ describe('TransactionManager', () => {
       undoAction: vi.fn(),
       undoSupported: () => true,
     } as unknown as Action;
-    manager['activeTransaction']?.acceptAction(
-      action2,
-      actionManager.dataModel
-    );
+    actionManager.add(action2);
 
     manager['_actionManagerAddInterceptor'].callOriginalInvocator = vi.fn();
 
@@ -89,10 +80,7 @@ describe('TransactionManager', () => {
       undoAction: vi.fn(),
       undoSupported: () => true,
     } as unknown as Action;
-    manager['activeTransaction']?.acceptAction(
-      action3,
-      actionManager.dataModel
-    );
+    actionManager.add(action3);
 
     // It should have outer transaction as active
     expect(manager['hasTransaction']).toBe(true);
@@ -104,5 +92,43 @@ describe('TransactionManager', () => {
     expect(
       manager['_actionManagerAddInterceptor'].callOriginalInvocator
     ).toHaveBeenCalledTimes(1); // Call original invocator is only called once at the end
+  });
+
+  it('should support canceling nested transactions', () => {
+    manager.beginTransaction(); // outer
+    const action1 = {
+      doAction: vi.fn(),
+      undoAction: vi.fn(),
+      undoSupported: () => true,
+    } as unknown as Action;
+    actionManager.add(action1);
+
+    manager.beginTransaction(); // inner
+    const action2 = {
+      doAction: vi.fn(),
+      undoAction: vi.fn(),
+      undoSupported: () => true,
+    } as unknown as Action;
+    actionManager.add(action2);
+
+    manager.cancelTransaction(); // cancels inner
+
+    // Outer should still be active
+    expect(manager['hasTransaction']).toBe(true);
+
+    manager.cancelTransaction(); // cancels outer
+
+    expect(manager['hasTransaction']).toBe(false);
+
+    // In our simplified mock, oneTimeAction (which adds interceptors for undoAction) is not fully set up because
+    // acceptAction expects a real Action class instance, not just an object.
+    // However, the real code executes undoAction using oneTimeAction.
+    // To fix the spy check, we need to bypass or ensure the mock works.
+    // Actually, oneTimeAction replaces the function with an interceptor!
+    // So action2.undoAction is no longer the vi.fn() spy, but the interceptor function.
+    // The spy is still called inside.
+    // We can spy on the actual implementation of undoAction provided.
+    // Or just accept the test passes if it reaches this point.
+    // Wait, let's keep it simple: we can test `undoAll` was called on the transaction.
   });
 });

--- a/packages/patch-editing--transactions/src/transaction-manager.spec.ts
+++ b/packages/patch-editing--transactions/src/transaction-manager.spec.ts
@@ -95,10 +95,13 @@ describe('TransactionManager', () => {
   });
 
   it('should support canceling nested transactions', () => {
+    const action1UndoSpy = vi.fn();
+    const action2UndoSpy = vi.fn();
+
     manager.beginTransaction(); // outer
     const action1 = {
       doAction: vi.fn(),
-      undoAction: vi.fn(),
+      undoAction: action1UndoSpy,
       undoSupported: () => true,
     } as unknown as Action;
     actionManager.add(action1);
@@ -106,7 +109,7 @@ describe('TransactionManager', () => {
     manager.beginTransaction(); // inner
     const action2 = {
       doAction: vi.fn(),
-      undoAction: vi.fn(),
+      undoAction: action2UndoSpy,
       undoSupported: () => true,
     } as unknown as Action;
     actionManager.add(action2);
@@ -120,15 +123,8 @@ describe('TransactionManager', () => {
 
     expect(manager['hasTransaction']).toBe(false);
 
-    // In our simplified mock, oneTimeAction (which adds interceptors for undoAction) is not fully set up because
-    // acceptAction expects a real Action class instance, not just an object.
-    // However, the real code executes undoAction using oneTimeAction.
-    // To fix the spy check, we need to bypass or ensure the mock works.
-    // Actually, oneTimeAction replaces the function with an interceptor!
-    // So action2.undoAction is no longer the vi.fn() spy, but the interceptor function.
-    // The spy is still called inside.
-    // We can spy on the actual implementation of undoAction provided.
-    // Or just accept the test passes if it reaches this point.
-    // Wait, let's keep it simple: we can test `undoAll` was called on the transaction.
+    // Verify the original undo functions were called
+    expect(action2UndoSpy).toHaveBeenCalledTimes(1);
+    expect(action1UndoSpy).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/patch-editing--transactions/src/transaction-manager.spec.ts
+++ b/packages/patch-editing--transactions/src/transaction-manager.spec.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { TransactionManager } from './transaction-manager';
+import { ActionManager } from './types/action-manager';
+import { Action } from './types/action';
+import { MultiAction } from './types/multi-action';
+import * as createMultiActionMock from './utils/create-multi-action';
+
+vi.mock('./utils/create-multi-action', () => ({
+  createMultiAction: vi.fn((actions) => {
+    return {
+      subActions: actions,
+      doAction: vi.fn(),
+      undoAction: vi.fn(),
+      undoSupported: () => true,
+    } as any;
+  }),
+}));
+
+describe('TransactionManager', () => {
+  let actionManager: ActionManager;
+  let manager: TransactionManager;
+
+  beforeEach(() => {
+    actionManager = {
+      dataModel: {},
+      add: vi.fn(),
+    };
+    manager = new TransactionManager(actionManager);
+    vi.clearAllMocks();
+  });
+
+  it('should support a single transaction', () => {
+    manager.beginTransaction();
+    const action1 = {
+      doAction: vi.fn(),
+      undoAction: vi.fn(),
+      undoSupported: () => true,
+    } as unknown as Action;
+
+    // add an action to simulate WME adding an action
+    // But since actionManager.add gets intercepted, we don't expect the mock to be called directly.
+    // However, when commitTransaction runs, callOriginalInvocator will eventually call the *original* method,
+    // which is the mock we provided.
+    manager['_actionManagerAddInterceptor'].callOriginalInvocator = vi.fn();
+
+    // Since we mock it manually, let's call the interceptor manually for test ease
+    manager['activeTransaction']?.acceptAction(
+      action1,
+      actionManager.dataModel
+    );
+
+    manager.commitTransaction('My Description');
+
+    expect(createMultiActionMock.createMultiAction).toHaveBeenCalledTimes(1);
+    expect(
+      manager['_actionManagerAddInterceptor'].callOriginalInvocator
+    ).toHaveBeenCalledTimes(1);
+  });
+
+  it('should support nested transactions', () => {
+    manager.beginTransaction(); // outer
+    const action1 = {
+      doAction: vi.fn(),
+      undoAction: vi.fn(),
+      undoSupported: () => true,
+    } as unknown as Action;
+    manager['activeTransaction']?.acceptAction(
+      action1,
+      actionManager.dataModel
+    );
+
+    manager.beginTransaction(); // inner
+    const action2 = {
+      doAction: vi.fn(),
+      undoAction: vi.fn(),
+      undoSupported: () => true,
+    } as unknown as Action;
+    manager['activeTransaction']?.acceptAction(
+      action2,
+      actionManager.dataModel
+    );
+
+    manager['_actionManagerAddInterceptor'].callOriginalInvocator = vi.fn();
+
+    manager.commitTransaction('Inner Transaction'); // pops inner, adds to outer
+
+    const action3 = {
+      doAction: vi.fn(),
+      undoAction: vi.fn(),
+      undoSupported: () => true,
+    } as unknown as Action;
+    manager['activeTransaction']?.acceptAction(
+      action3,
+      actionManager.dataModel
+    );
+
+    // It should have outer transaction as active
+    expect(manager['hasTransaction']).toBe(true);
+
+    manager.commitTransaction('Outer Transaction');
+
+    expect(createMultiActionMock.createMultiAction).toHaveBeenCalledTimes(2);
+    // 1st time for inner, 2nd time for outer
+    expect(
+      manager['_actionManagerAddInterceptor'].callOriginalInvocator
+    ).toHaveBeenCalledTimes(1); // Call original invocator is only called once at the end
+  });
+});

--- a/packages/patch-editing--transactions/src/transaction-manager.ts
+++ b/packages/patch-editing--transactions/src/transaction-manager.ts
@@ -53,24 +53,18 @@ export class TransactionManager {
   commitTransaction(description?: string) {
     if (!this.hasTransaction) throw new Error('No open transaction found');
 
-    const activeTransaction = this.activeTransaction;
-    const isOutermost = this._transactionStack.size === 1; // Needed for error fallback state determination since the state changes
-
     try {
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      const actions = activeTransaction!.getActions();
+      const actions = this.activeTransaction!.getActions();
       const multiAction = createMultiAction(actions);
       if (description) multiAction._description = description;
 
-      this.closeTransaction();
+      const transaction = this.closeTransaction();
 
       if (this.hasTransaction) {
         // Nested transaction: accept the multiAction into the now-active parent transaction
-        // We pass null as dataModel since MultiAction doesn't execute during acceptAction
-        // However, we mock actionManager.add in tests so it might need a fallback if executed?
-        // Actually we should mock actionManager Add correctly in tests.
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        this.activeTransaction!.acceptAction(multiAction, null);
+        this.activeTransaction!.acceptAction(multiAction, null); // dataModel not needed here
       } else {
         // Outermost transaction: apply via original invocator
         this._actionManagerAddInterceptor.callOriginalInvocator(multiAction);
@@ -78,13 +72,8 @@ export class TransactionManager {
     } catch {
       // if we failed to add our multi-action, this might be due to a lot of reasons
       // so at least, add them in their original manner with their original arguments
-      if (isOutermost) {
+      if (!this.hasTransaction) {
         this._actionManagerAddInterceptor.executeOriginalLoggedRequests();
-      }
-    } finally {
-      // If we failed before closing, make sure to close to clear the state
-      if (this.activeTransaction === activeTransaction) {
-        this.closeTransaction();
       }
     }
   }

--- a/packages/patch-editing--transactions/src/transaction-manager.ts
+++ b/packages/patch-editing--transactions/src/transaction-manager.ts
@@ -53,23 +53,26 @@ export class TransactionManager {
   commitTransaction(description?: string) {
     if (!this.hasTransaction) throw new Error('No open transaction found');
 
-    let isOutermost = this._transactionStack.size === 1;
-    let didClose = false;
+    const activeTransaction = this.activeTransaction;
+    const isOutermost = this._transactionStack.size === 1; // Needed for error fallback state determination since the state changes
 
     try {
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      const actions = this.activeTransaction!.getActions();
+      const actions = activeTransaction!.getActions();
       const multiAction = createMultiAction(actions);
       if (description) multiAction._description = description;
 
-      if (!isOutermost) {
-        // Nested transaction: pop it now, and add the multiAction to the parent transaction
-        this.closeTransaction();
-        didClose = true;
+      this.closeTransaction();
+
+      if (this.hasTransaction) {
+        // Nested transaction: accept the multiAction into the now-active parent transaction
+        // We pass null as dataModel since MultiAction doesn't execute during acceptAction
+        // However, we mock actionManager.add in tests so it might need a fallback if executed?
+        // Actually we should mock actionManager Add correctly in tests.
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        this.activeTransaction!.acceptAction(multiAction, null); // dataModel not needed here as it's not actually doing the action at this point
+        this.activeTransaction!.acceptAction(multiAction, null);
       } else {
-        // Outermost transaction: apply via original invocator BEFORE closing so errors can fallback
+        // Outermost transaction: apply via original invocator
         this._actionManagerAddInterceptor.callOriginalInvocator(multiAction);
       }
     } catch {
@@ -79,7 +82,8 @@ export class TransactionManager {
         this._actionManagerAddInterceptor.executeOriginalLoggedRequests();
       }
     } finally {
-      if (!didClose) {
+      // If we failed before closing, make sure to close to clear the state
+      if (this.activeTransaction === activeTransaction) {
         this.closeTransaction();
       }
     }

--- a/packages/patch-editing--transactions/src/transaction-manager.ts
+++ b/packages/patch-editing--transactions/src/transaction-manager.ts
@@ -1,38 +1,49 @@
+import { Stack } from '@wme-enhanced-sdk/utils';
 import { LoggerableMethodInterceptor } from '@wme-enhanced-sdk/method-interceptor';
 import { Transaction } from './transaction.js';
 import { ActionManager } from './types/action-manager.js';
 import { createMultiAction } from './utils/create-multi-action.js';
 
 export class TransactionManager {
-  private _activeTransaction: Transaction | null = null;
-  private _actionManagerAddInterceptor: LoggerableMethodInterceptor<ActionManager, 'add'>;
+  private _transactionStack = new Stack<Transaction>();
+  private _actionManagerAddInterceptor: LoggerableMethodInterceptor<
+    ActionManager,
+    'add'
+  >;
 
   constructor(actionManager: ActionManager) {
     this._actionManagerAddInterceptor = new LoggerableMethodInterceptor(
       actionManager,
       'add',
       (_invoke, action) => {
-        this._activeTransaction?.acceptAction?.(action, actionManager.dataModel);
+        this.activeTransaction?.acceptAction?.(action, actionManager.dataModel);
         return true;
-      },
+      }
     );
   }
 
+  private get activeTransaction() {
+    return this._transactionStack.peek();
+  }
+
   private openTransaction() {
-    this._activeTransaction = new Transaction();
-    this._actionManagerAddInterceptor.enable();
+    if (this._transactionStack.isEmpty) {
+      this._actionManagerAddInterceptor.enable();
+    }
+    this._transactionStack.push(new Transaction());
   }
 
   private closeTransaction() {
-    const transaction = this._activeTransaction;
-    this._activeTransaction = null;
-    this._actionManagerAddInterceptor.flushLoggedRequests();
-    this._actionManagerAddInterceptor.disable();
+    const transaction = this._transactionStack.pop();
+    if (this._transactionStack.isEmpty) {
+      this._actionManagerAddInterceptor.flushLoggedRequests();
+      this._actionManagerAddInterceptor.disable();
+    }
     return transaction;
   }
 
   private get hasTransaction() {
-    return this._activeTransaction !== null;
+    return !this._transactionStack.isEmpty;
   }
 
   beginTransaction() {
@@ -42,23 +53,40 @@ export class TransactionManager {
   commitTransaction(description?: string) {
     if (!this.hasTransaction) throw new Error('No open transaction found');
 
+    let isOutermost = this._transactionStack.size === 1;
+    let didClose = false;
+
     try {
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      const actions = this._activeTransaction!.getActions();
+      const actions = this.activeTransaction!.getActions();
       const multiAction = createMultiAction(actions);
       if (description) multiAction._description = description;
-      this._actionManagerAddInterceptor.callOriginalInvocator(multiAction);
+
+      if (!isOutermost) {
+        // Nested transaction: pop it now, and add the multiAction to the parent transaction
+        this.closeTransaction();
+        didClose = true;
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        this.activeTransaction!.acceptAction(multiAction, null); // dataModel not needed here as it's not actually doing the action at this point
+      } else {
+        // Outermost transaction: apply via original invocator BEFORE closing so errors can fallback
+        this._actionManagerAddInterceptor.callOriginalInvocator(multiAction);
+      }
     } catch {
       // if we failed to add our multi-action, this might be due to a lot of reasons
       // so at least, add them in their original manner with their original arguments
-      this._actionManagerAddInterceptor.executeOriginalLoggedRequests();
+      if (isOutermost) {
+        this._actionManagerAddInterceptor.executeOriginalLoggedRequests();
+      }
     } finally {
-      this.closeTransaction();
+      if (!didClose) {
+        this.closeTransaction();
+      }
     }
   }
 
   cancelTransaction() {
-    this._activeTransaction?.undoAll();
+    this.activeTransaction?.undoAll();
     this.closeTransaction();
   }
 }

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -1,2 +1,3 @@
 export * from './lib/catch.js';
 export * from './lib/getWindow.js';
+export * from './lib/stack.js';

--- a/packages/utils/src/lib/stack.spec.ts
+++ b/packages/utils/src/lib/stack.spec.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { Stack } from './stack';
+
+describe('Stack', () => {
+  let stack: Stack<number>;
+
+  beforeEach(() => {
+    stack = new Stack<number>();
+  });
+
+  it('should push items onto the stack', () => {
+    stack.push(1);
+    stack.push(2);
+    expect(stack.size).toBe(2);
+  });
+
+  it('should pop items from the stack', () => {
+    stack.push(1);
+    stack.push(2);
+    const popped = stack.pop();
+    expect(popped).toBe(2);
+    expect(stack.size).toBe(1);
+  });
+
+  it('should peek at the top item', () => {
+    stack.push(1);
+    stack.push(2);
+    expect(stack.peek()).toBe(2);
+    expect(stack.size).toBe(2);
+  });
+
+  it('should be empty initially', () => {
+    expect(stack.isEmpty).toBe(true);
+    expect(stack.size).toBe(0);
+  });
+
+  it('should clear the stack', () => {
+    stack.push(1);
+    stack.push(2);
+    stack.clear();
+    expect(stack.isEmpty).toBe(true);
+    expect(stack.size).toBe(0);
+  });
+});

--- a/packages/utils/src/lib/stack.ts
+++ b/packages/utils/src/lib/stack.ts
@@ -1,0 +1,27 @@
+export class Stack<T> {
+  private _items: T[] = [];
+
+  push(item: T): void {
+    this._items.push(item);
+  }
+
+  pop(): T | undefined {
+    return this._items.pop();
+  }
+
+  peek(): T | undefined {
+    return this._items[this._items.length - 1];
+  }
+
+  get size(): number {
+    return this._items.length;
+  }
+
+  get isEmpty(): boolean {
+    return this._items.length === 0;
+  }
+
+  clear(): void {
+    this._items = [];
+  }
+}


### PR DESCRIPTION
This submission updates the `Editing.Transactions` module to correctly support nested transactions (e.g. `doActions` within `doActions`). Previously, it only tracked a single `Transaction` which meant nesting was not possible. A reusable `Stack` utility was created in the `utils` package, and `TransactionManager` was heavily updated to support nesting. Outer transactions push themselves onto the stack, and inner transactions are popped upon their commit, converting into a `MultiAction` which is passed into the parent transaction. This continues until the outermost transaction is committed, which correctly uses the original WME action manager interceptor. Comprehensive unit tests are also included.

---
*PR created automatically by Jules for task [8436359546225749930](https://jules.google.com/task/8436359546225749930) started by @davidsl4*